### PR TITLE
Initialize coding standards and contributor docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+- Describe your changes
+
+## Related Issues
+- Link roadmap tasks you addressed
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Code formatted with pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.0
+    hooks:
+      - id: black
+        args: ["--line-length=88"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.3
+    hooks:
+      - id: ruff
+        args: ["--line-length=88"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@ Welcome!  This checklist tracks every deliverable required to lift DieselWolf fr
 
 ## 1. Repository House‑Keeping
 - [ ] **Adopt Coding Standards**
-  - [ ] Add `ruff` + `black` pre‑commit hooks
-  - [ ] Create `CONTRIBUTING.md` and PR template  
+  - [x] Add `ruff` + `black` pre‑commit hooks (`469c913`)
+  - [x] Create `CONTRIBUTING.md` and PR template (`469c913`)
 - [ ] **Environment**
-  - [ ] Pin dependencies in `pyproject.toml`
-  - [ ] Add `requirements-dev.txt` for docs, lint, tests
+  - [x] Pin dependencies in `pyproject.toml` (`469c913`)
+  - [x] Add `requirements-dev.txt` for docs, lint, tests (`469c913`)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to DieselWolf
+
+Thanks for taking the time to contribute! Please follow these guidelines to keep the project tidy and consistent.
+
+## Development environment
+
+1. Install Python 3.8 or later.
+2. Install dependencies from `pyproject.toml`:
+   ```bash
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   ```
+3. Install pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+
+## Style
+
+We use **Black** and **Ruff** to maintain code quality. The hooks run automatically via `pre-commit`.
+Run `pre-commit run --all-files` before pushing to ensure your code is formatted and linted.
+
+## Pull requests
+
+- Create feature branches from `main`.
+- Ensure tests pass (`pytest` will be added in future).
+- Reference roadmap items in your PR description.
+
+Happy hacking!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "dieselwolf"
+version = "0.1.0"
+description = "Automatic Modulation Recognition research platform"
+readme = "README.md"
+requires-python = ">=3.8"
+
+dependencies = [
+    "torch==2.0.1",
+    "numba==0.58.1",
+    "numpy==1.26.0",
+    "matplotlib==3.8.0",
+    "scikit-learn==1.3.0",
+    "scipy==1.11.0",
+    "jupyter==1.0.0",
+    "typing_extensions==4.7.1",
+    "reformer-pytorch==1.4.4",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py38"]
+
+[tool.ruff]
+line-length = 88

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pre-commit
+black==25.1.0
+ruff==0.4.3
+pytest


### PR DESCRIPTION
## Summary
- add pyproject with pinned deps and formatter config
- set up pre-commit with black and ruff
- add contributing guide and PR template
- track completed tasks in AGENTS roadmap

## Testing
- `pre-commit run --files AGENTS.md pyproject.toml .pre-commit-config.yaml requirements-dev.txt CONTRIBUTING.md .github/pull_request_template.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2a756e30832aac9f807b4d0e0a84