### PR TITLE
Add MobileRaT backbone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,12 @@ Welcome!  This checklist tracks every deliverable required to lift DieselWolf fr
 ---
 
 ## 3. Model‑Architecture Upgrades
-- [ ] **Complex‑Valued Core**
+- [x] **Complex‑Valued Core** (`c84d441`)
   - [x] Replace `nn.Conv1d`, `BatchNorm1d`, `Linear` with `ComplexConv1d`, etc. (`2cd4d66`)
   - [x] Replace Replace Reformer with a complex‑valued Transformer (CV‑ViT or CC‑MSNet) (`1cfef0b`)
   - [x] Verify weight initialisation & checkpoint I/O (`6d28f30`)
 - [ ] **Introduce Radio‑Transformers**
-  - [ ] Add **MobileRaT** backbone
+  - [x] Add **MobileRaT** backbone (`c84d441`)
   - [ ] Add **NMformer** backbone with noise tokens
   - [ ] Provide YAML configs for both
 - [ ] **Hybrid Multitask Heads**

--- a/dieselwolf/models/__init__.py
+++ b/dieselwolf/models/__init__.py
@@ -2,5 +2,6 @@
 
 from .lightning_module import AMRClassifier
 from .complex_transformer import ComplexTransformerEncoder
+from .mobile_rat import MobileRaT
 
-__all__ = ["AMRClassifier", "ComplexTransformerEncoder"]
+__all__ = ["AMRClassifier", "ComplexTransformerEncoder", "MobileRaT"]

--- a/dieselwolf/models/complex_transformer.py
+++ b/dieselwolf/models/complex_transformer.py
@@ -34,7 +34,13 @@ class ComplexTransformerEncoderLayer(nn.Module):
         src = src + self.dropout1(attn_output)
         src = self.norm1(src)
 
-        ff = self.linear2(self.dropout(self.activation(self.linear1(src))))
+        # feed-forward expects features in last dimension
+        ff = src.permute(0, 2, 1)
+        ff = self.linear1(ff)
+        ff = self.activation(ff)
+        ff = self.dropout(ff)
+        ff = self.linear2(ff)
+        ff = ff.permute(0, 2, 1)
         src = src + self.dropout2(ff)
         src = self.norm2(src)
         return src

--- a/dieselwolf/models/mobile_rat.py
+++ b/dieselwolf/models/mobile_rat.py
@@ -1,0 +1,35 @@
+import torch
+from torch import nn
+
+from ..complex_layers import ComplexBatchNorm1d, ComplexConv1d
+from .complex_transformer import ComplexTransformerEncoder
+
+
+class MobileRaT(nn.Module):
+    """Lightweight complex-valued Radio Transformer backbone."""
+
+    def __init__(
+        self,
+        seq_len: int,
+        num_classes: int,
+        d_model: int = 32,
+        nhead: int = 4,
+        num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+        self.seq_len = seq_len
+        self.frontend = nn.Sequential(
+            ComplexConv1d(1, d_model, kernel_size=3, padding=1),
+            ComplexBatchNorm1d(d_model),
+            nn.ReLU(),
+        )
+        self.transformer = ComplexTransformerEncoder(
+            d_model=d_model, nhead=nhead, num_layers=num_layers
+        )
+        self.classifier = nn.Linear(2 * d_model * seq_len, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.frontend(x)
+        x = self.transformer(x)
+        x = x.flatten(1)
+        return self.classifier(x)

--- a/tests/test_mobile_rat.py
+++ b/tests/test_mobile_rat.py
@@ -1,0 +1,10 @@
+import torch
+
+from dieselwolf.models.mobile_rat import MobileRaT
+
+
+def test_mobile_rat_forward():
+    model = MobileRaT(seq_len=32, num_classes=3)
+    x = torch.randn(2, 2, 32)
+    out = model(x)
+    assert out.shape == (2, 3)


### PR DESCRIPTION
## Summary
- implement a lightweight MobileRaT model
- fix complex transformer feed-forward dimensions
- export MobileRaT in the models package
- add unit test for the new backbone
- mark roadmap tasks completed

## Testing
- `pre-commit run --files dieselwolf/models/mobile_rat.py dieselwolf/models/__init__.py tests/test_mobile_rat.py dieselwolf/models/complex_transformer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5eddc44c832ab84fc5ced14b03b2