### PR TITLE
Implement SNR regression head

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,12 +32,12 @@ Welcome!  This checklist tracks every deliverable required to lift DieselWolf fr
   - [x] Replace `nn.Conv1d`, `BatchNorm1d`, `Linear` with `ComplexConv1d`, etc. (`2cd4d66`)
   - [x] Replace Replace Reformer with a complex‑valued Transformer (CV‑ViT or CC‑MSNet) (`1cfef0b`)
   - [x] Verify weight initialisation & checkpoint I/O (`6d28f30`)
-- [ ] **Introduce Radio‑Transformers**
+- [x] **Introduce Radio‑Transformers** (`df5681a`)
   - [x] Add **MobileRaT** backbone (`c84d441`)
   - [x] Add **NMformer** backbone with noise tokens (`78d6a02`)
   - [x] Provide YAML configs for both (`78d6a02`)
 - [ ] **Hybrid Multitask Heads**
-  - [ ] Append SNR‑regression head
+  - [x] Append SNR‑regression head (`df5681a`)
   - [ ] Append channel‑parameter (CFO & phase) head
   - [ ] Balance multi‑loss weights via grid search
 

--- a/tests/test_amrclassifier.py
+++ b/tests/test_amrclassifier.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn as nn
+
+from dieselwolf.models import AMRClassifier
+
+
+class DummyNet(nn.Module):
+    def __init__(self, num_classes: int) -> None:
+        super().__init__()
+        self.fc = nn.Linear(4, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x.flatten(1))
+
+
+def test_amrclassifier_snr_forward():
+    model = AMRClassifier(DummyNet(num_classes=3), num_classes=3, predict_snr=True)
+    x = torch.randn(2, 2, 2)
+    logits, snr = model(x)
+    assert logits.shape == (2, 3)
+    assert snr.shape == (2,)
+
+
+def test_amrclassifier_training_step_snr():
+    model = AMRClassifier(DummyNet(num_classes=3), num_classes=3, predict_snr=True)
+    batch = {
+        "data": torch.randn(2, 2, 2),
+        "label": torch.tensor([0, 1]),
+        "metadata": {"SNRdB": torch.tensor([10.0, 5.0])},
+    }
+    loss = model.training_step(batch, 0)
+    assert loss.item() > 0


### PR DESCRIPTION
## Summary
- add optional SNR regression head to `AMRClassifier`
- create tests for AMRClassifier with SNR support
- update project roadmap

## Testing
- `pre-commit run --files dieselwolf/models/lightning_module.py tests/test_amrclassifier.py AGENTS.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f661df80c832aab7eb4364cf86250