### PR TITLE
Add channel parameter head

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Welcome!  This checklist tracks every deliverable required to lift DieselWolf fr
   - [x] Provide YAML configs for both (`78d6a02`)
 - [ ] **Hybrid Multitask Heads**
   - [x] Append SNR‑regression head (`df5681a`)
-  - [ ] Append channel‑parameter (CFO & phase) head
+  - [x] Append channel‑parameter (CFO & phase) head (`02e77b3`)
   - [ ] Balance multi‑loss weights via grid search
 
 ---

--- a/tests/test_amrclassifier.py
+++ b/tests/test_amrclassifier.py
@@ -21,12 +21,34 @@ def test_amrclassifier_snr_forward():
     assert snr.shape == (2,)
 
 
+def test_amrclassifier_channel_forward():
+    model = AMRClassifier(DummyNet(num_classes=3), num_classes=3, predict_channel=True)
+    x = torch.randn(2, 2, 2)
+    logits, channel = model(x)
+    assert logits.shape == (2, 3)
+    assert channel.shape == (2, 2)
+
+
 def test_amrclassifier_training_step_snr():
     model = AMRClassifier(DummyNet(num_classes=3), num_classes=3, predict_snr=True)
     batch = {
         "data": torch.randn(2, 2, 2),
         "label": torch.tensor([0, 1]),
         "metadata": {"SNRdB": torch.tensor([10.0, 5.0])},
+    }
+    loss = model.training_step(batch, 0)
+    assert loss.item() > 0
+
+
+def test_amrclassifier_training_step_channel():
+    model = AMRClassifier(DummyNet(num_classes=3), num_classes=3, predict_channel=True)
+    batch = {
+        "data": torch.randn(2, 2, 2),
+        "label": torch.tensor([0, 1]),
+        "metadata": {
+            "CarrierFrequencyOffset": torch.tensor([0.1, 0.2]),
+            "CarrierPhaseOffset": torch.tensor([10.0, 5.0]),
+        },
     }
     loss = model.training_step(batch, 0)
     assert loss.item() > 0


### PR DESCRIPTION
## Summary
- extend `AMRClassifier` with optional channel head for CFO & phase
- test forward and training with the new head
- check off AGENTS item for channel head

## Testing
- `ruff check dieselwolf/models/lightning_module.py tests/test_amrclassifier.py`
- `black dieselwolf/models/lightning_module.py tests/test_amrclassifier.py --check`
- `pytest -q` *(fails: ImportError: libcudnn.so.8)*

------
https://chatgpt.com/codex/tasks/task_e_685f691950cc832aa8d62c3a01553e9e