### PR TITLE
Implement QPSK interference simulation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,9 @@ Welcome!  This checklist tracks every deliverable required to lift DieselWolf fr
   - [x] TDL Rayleigh (`7f76c44`)
   - [x] Rician K‑factor sweep (`83b3629`)
   - [x] Nakagami‑m option (`83b3629`)
-- [ ] **Interference Simulation**
-  - [ ] Add co‑channel QPSK interferer mix‑in
-  - [ ] Label jammer SNR for possible auxiliary training
+- [x] **Interference Simulation** (`098684d`)
+  - [x] Add co‑channel QPSK interferer mix‑in (`098684d`)
+  - [x] Label jammer SNR for possible auxiliary training (`098684d`)
 
 ---
 

--- a/tests/test_cochannel_interferer.py
+++ b/tests/test_cochannel_interferer.py
@@ -1,0 +1,27 @@
+import importlib.util
+import pathlib
+import torch
+
+spec = importlib.util.spec_from_file_location(
+    "TransformsRF",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "dieselwolf"
+    / "data"
+    / "TransformsRF.py",
+)
+transforms = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transforms)
+CoChannelQPSKInterferer = transforms.CoChannelQPSKInterferer
+
+
+def test_cochannel_qpsk_interferer_power():
+    torch.manual_seed(0)
+    item = {"data": torch.ones(2, 64), "metadata": {}}
+    transform = CoChannelQPSKInterferer(sir_dB=10, seed=0)
+    out = transform({"data": item["data"].clone(), "metadata": {}})
+    interference = out["data"] - item["data"]
+    p_signal = item["data"].pow(2).mean()
+    p_interf = interference.pow(2).mean()
+    ratio_db = 10 * torch.log10(p_signal / p_interf)
+    assert abs(ratio_db.item() - 10) < 0.5
+    assert out["metadata"]["JammerSNRdB"] == 10


### PR DESCRIPTION
## Summary
- introduce `CoChannelQPSKInterferer` transform for adding a QPSK jammer
- add a unit test validating jammer power and metadata
- mark interference simulation tasks complete in roadmap

## Testing
- `pre-commit run --files AGENTS.md dieselwolf/data/TransformsRF.py tests/test_cochannel_interferer.py`
- `PYTHONPATH=. pytest tests/test_cochannel_interferer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865556db190832ab8f6155fb958e78c