### PR TITLE
Implement EMA checkpoint saving

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Welcome!  This checklist tracks every deliverable required to lift DieselWolf fr
   - [x] Enable AMP in Trainer (`00a5384`)
   - [x] Tune `accumulate_grad_batches` for batch‑equivalent training (`00a5384`)
 - [ ] **Checkpoint & Resume**
-  - [ ] Save EMA weights
+  - [x] Save EMA weights (`ee33620`)
   - [ ] Resume SSL → fine‑tune seamlessly
 
 ---

--- a/scripts/train_amr.py
+++ b/scripts/train_amr.py
@@ -2,7 +2,11 @@ import argparse
 
 import pytorch_lightning as pl
 import torch
-from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
+from pytorch_lightning.callbacks import (
+    LearningRateMonitor,
+    ModelCheckpoint,
+    EMA,
+)
 from torch import nn
 from torch.utils.data import DataLoader
 
@@ -45,6 +49,12 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Gradient accumulation steps",
     )
+    parser.add_argument(
+        "--ema-decay",
+        type=float,
+        default=0.0,
+        help="Exponential moving average decay. Set 0 to disable.",
+    )
     return parser.parse_args()
 
 
@@ -77,6 +87,8 @@ def main() -> None:
         ModelCheckpoint(save_top_k=1, monitor="val_loss"),
         LearningRateMonitor(),
     ]
+    if args.ema_decay > 0:
+        callbacks.append(EMA(decay=args.ema_decay, use_ema_weights=True))
     trainer = pl.Trainer(
         max_epochs=args.epochs,
         precision=args.precision,


### PR DESCRIPTION
## Summary
- add EMA callback support to `train_amr.py`
- document completion of the EMA checkpoint task

## Testing
- `pre-commit run --files scripts/train_amr.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655c58edc0832a83a6a0fd5ed6ce16