### PR TITLE
Add tutorial notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,11 @@ Three Jupyter notebooks with examples showing dataset and models in use.
     Modulation_Classification: Training a hybrid model to perform automatic modulation recognition.
     Demodulation: Training a model to demodulate a signal.
 
+Additional tutorial notebooks can be found in the `notebooks/` directory:
+
+    Dataset_Tutorial: Overview of dataset generation and visualisation.
+    Training_Tutorial: Example of training with PyTorch Lightning.
+    Evaluation_Tutorial: Demonstrates metrics and benchmark utilities.
+
 docker build -t dieselmod .
 docker run --gpus all -it --rm -p 8888:8888 -v ${pwd}:/app dieselmod

--- a/notebooks/Dataset_Tutorial.ipynb
+++ b/notebooks/Dataset_Tutorial.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0550b502",
+   "metadata": {},
+   "source": [
+    "# DieselWolf Dataset Tutorial\n",
+    "This notebook demonstrates how to generate I/Q samples using the `DigitalModulationDataset` and visualize them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f0daefc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dieselwolf.data import DigitalModulationDataset\n",
+    "from dieselwolf.data.TransformsRF import AWGN\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b1c1304",
+   "metadata": {},
+   "source": [
+    "## Create the dataset\n",
+    "We generate a small dataset with only a few examples for demonstration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb219feb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = DigitalModulationDataset(num_examples=2, num_samples=128, transform=AWGN(10))\n",
+    "print('Classes:', dataset.classes)\n",
+    "print('Dataset length:', len(dataset))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2964e1c1",
+   "metadata": {},
+   "source": [
+    "## Visualize an example\n",
+    "The dataset returns a dictionary containing the I/Q data and metadata. We can plot the in-phase and quadrature components."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "178a8d23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "item = dataset[0]\n",
+    "iq = item['data']\n",
+    "plt.figure(figsize=(10,3))\n",
+    "plt.plot(iq[0], label='I')\n",
+    "plt.plot(iq[1], label='Q')\n",
+    "plt.title(f'Modulation: {dataset.classes[item['label']]}')\n",
+    "plt.xlabel('Sample')\n",
+    "plt.ylabel('Amplitude')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f106c8ad",
+   "metadata": {},
+   "source": [
+    "## Using in a DataLoader\n",
+    "We can wrap the dataset in a PyTorch `DataLoader` for batching during training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fb173a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import DataLoader\n",
+    "loader = DataLoader(dataset, batch_size=2)\n",
+    "batch = next(iter(loader))\n",
+    "print(batch['data'].shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c7c98fe",
+   "metadata": {},
+   "source": [
+    "This concludes the basic dataset overview."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Evaluation_Tutorial.ipynb
+++ b/notebooks/Evaluation_Tutorial.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "248d2e2f",
+   "metadata": {},
+   "source": [
+    "# DieselWolf Evaluation Tutorial\n",
+    "This notebook demonstrates how to compute evaluation metrics and visualize results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfffa273",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dieselwolf.metrics import accuracy_per_snr, confusion_at_0db\n",
+    "import torch\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "022e176a",
+   "metadata": {},
+   "source": [
+    "## Generate dummy predictions\n",
+    "For demonstration we create random predictions and SNR values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a97963d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "targets = torch.tensor([0,1,0,1,0,1])\n",
+    "preds = torch.tensor([0,1,1,1,0,0])\n",
+    "snr = torch.tensor([0,0,5,5,10,10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "830e4e30",
+   "metadata": {},
+   "source": [
+    "## Accuracy by SNR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e110f614",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc = accuracy_per_snr(preds, targets, snr)\n",
+    "plt.bar(acc.keys(), acc.values())\n",
+    "plt.xlabel('SNR (dB)')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c896fbb",
+   "metadata": {},
+   "source": [
+    "## Confusion matrix at 0 dB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e4d30a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm = confusion_at_0db(preds, targets, snr)\n",
+    "print(cm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04fc75dc",
+   "metadata": {},
+   "source": [
+    "These utilities help benchmark models under different conditions."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Training_Tutorial.ipynb
+++ b/notebooks/Training_Tutorial.ipynb
@@ -1,0 +1,84 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2efb333c",
+   "metadata": {},
+   "source": [
+    "# DieselWolf Training Tutorial\n",
+    "This notebook trains a simple AMR classifier using PyTorch Lightning. The goal is to illustrate the training loop and callbacks provided in the repository."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88c2b406",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dieselwolf.data import DigitalModulationDataset\n",
+    "from dieselwolf.data.TransformsRF import AWGN\n",
+    "from dieselwolf.models import AMRClassifier, MobileRaT\n",
+    "from dieselwolf.callbacks import SNRCurriculumCallback\n",
+    "import pytorch_lightning as pl\n",
+    "from pytorch_lightning.callbacks import LearningRateMonitor\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a1e8938",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "train_ds = DigitalModulationDataset(num_examples=4, num_samples=128, transform=AWGN(20))\n",
+    "val_ds = DigitalModulationDataset(num_examples=2, num_samples=128, transform=AWGN(20))\n",
+    "train_loader = DataLoader(train_ds, batch_size=2, shuffle=True)\n",
+    "val_loader = DataLoader(val_ds, batch_size=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f02a943e",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "backbone = MobileRaT(seq_len=128, num_classes=len(train_ds.classes))\n",
+    "model = AMRClassifier(backbone, num_classes=len(train_ds.classes), warmup_steps=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "faa5952f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "callbacks=[LearningRateMonitor(), SNRCurriculumCallback(train_ds, start_snr=20, patience=1)]\n",
+    "trainer = pl.Trainer(max_epochs=1, enable_progress_bar=False)\n",
+    "trainer.fit(model, train_loader, val_loader)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99326a63",
+   "metadata": {},
+   "source": [
+    "The model trains for a single epoch for speed. In a real experiment you would run for many more epochs."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- introduce three educational notebooks covering dataset, training and evaluation
- reference them in README

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6865a6ca66cc832a8732d40395a53545