### PR TITLE
Add backbone factory and config support

### DIFF
--- a/dieselwolf/__init__.py
+++ b/dieselwolf/__init__.py
@@ -1,4 +1,5 @@
 from .tuning import grid_search_loss_weights
 from .callbacks import SNRCurriculumCallback
+from .models import build_backbone
 
-__all__ = ["grid_search_loss_weights", "SNRCurriculumCallback"]
+__all__ = ["grid_search_loss_weights", "SNRCurriculumCallback", "build_backbone"]

--- a/dieselwolf/models/__init__.py
+++ b/dieselwolf/models/__init__.py
@@ -5,6 +5,7 @@ from .complex_transformer import ComplexTransformerEncoder
 from .mobile_rat import MobileRaT
 from .nmformer import NMformer
 from .moco_v3 import MoCoV3
+from .factory import build_backbone
 
 __all__ = [
     "AMRClassifier",
@@ -12,4 +13,5 @@ __all__ = [
     "MobileRaT",
     "NMformer",
     "MoCoV3",
+    "build_backbone",
 ]

--- a/dieselwolf/models/factory.py
+++ b/dieselwolf/models/factory.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Union
+
+import yaml
+from torch import nn
+
+from .mobile_rat import MobileRaT
+from .nmformer import NMformer
+
+
+_BACKBONES = {
+    "MobileRaT": MobileRaT,
+    "NMformer": NMformer,
+}
+
+
+def build_backbone(cfg: Union[str, Path, Mapping[str, Any]]) -> nn.Module:
+    """Instantiate a backbone from a YAML config or dictionary.
+
+    Parameters
+    ----------
+    cfg:
+        Either a mapping containing the configuration or a path to a YAML file.
+
+    Returns
+    -------
+    nn.Module
+        Instantiated backbone model.
+    """
+    if not isinstance(cfg, Mapping):
+        with open(Path(cfg), "r") as f:
+            cfg_dict: MutableMapping[str, Any] = yaml.safe_load(f)
+    else:
+        cfg_dict = dict(cfg)
+
+    name = cfg_dict.get("backbone")
+    seq_len = cfg_dict.get("seq_len")
+    num_classes = cfg_dict.get("num_classes")
+    params = cfg_dict.get("params", {})
+
+    if name not in _BACKBONES:
+        raise ValueError(f"Unknown backbone '{name}'")
+    if seq_len is None or num_classes is None:
+        raise ValueError("'seq_len' and 'num_classes' must be specified")
+
+    cls = _BACKBONES[name]
+    return cls(seq_len=seq_len, num_classes=num_classes, **params)

--- a/scripts/pretrain_ssl.py
+++ b/scripts/pretrain_ssl.py
@@ -9,7 +9,7 @@ from dieselwolf.data import (
     RadioML2018Dataset,
     RFAugment,
 )
-from dieselwolf.models import MobileRaT, MoCoV3
+from dieselwolf.models import MoCoV3, build_backbone
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,6 +27,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--radio2018", type=str, default=None, help="Path to RadioML2018 dataset"
+    )
+    parser.add_argument(
+        "--model-config",
+        type=str,
+        default=None,
+        help="YAML file specifying the backbone for the encoder",
     )
     return parser.parse_args()
 
@@ -49,7 +55,10 @@ def main() -> None:
     train_ds = ConcatDataset(datasets)
     loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
 
-    backbone = MobileRaT()
+    if args.model_config:
+        backbone = build_backbone(args.model_config)
+    else:
+        backbone = build_backbone("configs/mobile_rat.yaml")
     model = MoCoV3(
         encoder=backbone,
         feature_dim=args.feature_dim,

--- a/scripts/train_amr.py
+++ b/scripts/train_amr.py
@@ -14,7 +14,7 @@ from torch import nn
 from torch.utils.data import DataLoader
 
 from dieselwolf.data import DigitalModulationDataset
-from dieselwolf.models import AMRClassifier
+from dieselwolf.models import AMRClassifier, build_backbone
 
 
 class SimpleCNN(nn.Module):
@@ -70,6 +70,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Path to MoCo checkpoint for fine-tuning",
     )
+    parser.add_argument(
+        "--model-config",
+        type=str,
+        default=None,
+        help="Path to YAML file specifying the backbone configuration",
+    )
     return parser.parse_args()
 
 
@@ -92,7 +98,10 @@ def main() -> None:
     )
     val_loader = DataLoader(val_ds, batch_size=args.batch_size)
 
-    backbone = SimpleCNN(args.num_samples, len(train_ds.classes))
+    if args.model_config:
+        backbone = build_backbone(args.model_config)
+    else:
+        backbone = SimpleCNN(args.num_samples, len(train_ds.classes))
     model = AMRClassifier(
         backbone,
         num_classes=len(train_ds.classes),

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,36 @@
+import yaml
+import torch
+
+from dieselwolf.models import build_backbone, MobileRaT, NMformer
+
+
+def test_build_mobile_rat(tmp_path):
+    cfg = {
+        "backbone": "MobileRaT",
+        "seq_len": 32,
+        "num_classes": 3,
+        "params": {"d_model": 16, "nhead": 2, "num_layers": 1},
+    }
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    model = build_backbone(path)
+    x = torch.randn(1, 2, 32)
+    out = model(x)
+    assert isinstance(model, MobileRaT)
+    assert out.shape == (1, 3)
+
+
+def test_build_nmformer(tmp_path):
+    cfg = {
+        "backbone": "NMformer",
+        "seq_len": 32,
+        "num_classes": 4,
+        "params": {"d_model": 16, "nhead": 2, "num_layers": 1, "num_noise_tokens": 2},
+    }
+    path = tmp_path / "cfg.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+    model = build_backbone(path)
+    x = torch.randn(1, 2, 32)
+    out = model(x)
+    assert isinstance(model, NMformer)
+    assert out.shape == (1, 4)


### PR DESCRIPTION
## Summary
- add `build_backbone` utility for YAML-based backbone creation
- expose the new factory in package init
- support `--model-config` in training and pretraining scripts
- test new factory

## Testing
- `pre-commit run --files dieselwolf/models/factory.py dieselwolf/models/__init__.py scripts/train_amr.py scripts/pretrain_ssl.py dieselwolf/__init__.py tests/test_factory.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865aeba2a3c832abc633d9dbebb3c6f