### PR TITLE
Add configurable CNN backbone

### DIFF
--- a/dieselwolf/models/__init__.py
+++ b/dieselwolf/models/__init__.py
@@ -4,6 +4,7 @@ from .lightning_module import AMRClassifier
 from .complex_transformer import ComplexTransformerEncoder
 from .mobile_rat import MobileRaT
 from .nmformer import NMformer
+from .configurable_cnn import ConfigurableCNN
 from .moco_v3 import MoCoV3
 from .factory import build_backbone
 
@@ -12,6 +13,7 @@ __all__ = [
     "ComplexTransformerEncoder",
     "MobileRaT",
     "NMformer",
+    "ConfigurableCNN",
     "MoCoV3",
     "build_backbone",
 ]

--- a/dieselwolf/models/configurable_cnn.py
+++ b/dieselwolf/models/configurable_cnn.py
@@ -1,0 +1,52 @@
+import torch
+from torch import nn
+from typing import Sequence
+
+
+class ConfigurableCNN(nn.Module):
+    """Flexible 1D CNN for AMR experiments."""
+
+    def __init__(
+        self,
+        seq_len: int,
+        num_classes: int,
+        conv_channels: Sequence[int] | int = (32,),
+        kernel_sizes: Sequence[int] | int = 3,
+        batch_norm: bool = False,
+        activation: str = "relu",
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        if isinstance(conv_channels, int):
+            conv_channels = [conv_channels]
+        if isinstance(kernel_sizes, int):
+            kernel_sizes = [kernel_sizes] * len(conv_channels)
+        if len(conv_channels) != len(kernel_sizes):
+            raise ValueError("conv_channels and kernel_sizes must have same length")
+
+        act_map = {
+            "relu": nn.ReLU,
+            "leakyrelu": nn.LeakyReLU,
+            "tanh": nn.Tanh,
+        }
+        act_cls = act_map.get(activation.lower())
+        if act_cls is None:
+            raise ValueError(f"Unknown activation '{activation}'")
+
+        layers: list[nn.Module] = []
+        in_ch = 2
+        for out_ch, k in zip(conv_channels, kernel_sizes):
+            layers.append(nn.Conv1d(in_ch, out_ch, kernel_size=k, padding=k // 2))
+            if batch_norm:
+                layers.append(nn.BatchNorm1d(out_ch))
+            layers.append(act_cls())
+            if dropout > 0:
+                layers.append(nn.Dropout(dropout))
+            in_ch = out_ch
+        self.conv = nn.Sequential(*layers)
+        self.classifier = nn.Linear(in_ch * seq_len, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        x = self.conv(x)
+        x = x.flatten(1)
+        return self.classifier(x)

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -9,23 +9,7 @@ from torch.utils.data import DataLoader
 
 from dieselwolf.data import DigitalModulationDataset
 from dieselwolf.metrics import accuracy_per_snr, confusion_at_0db, measure_latency
-from dieselwolf.models import AMRClassifier
-
-
-class SimpleCNN(nn.Module):
-    """Very small CNN used for quick benchmarks."""
-
-    def __init__(self, num_samples: int, num_classes: int) -> None:
-        super().__init__()
-        self.net = nn.Sequential(
-            nn.Conv1d(2, 32, kernel_size=3, padding=1),
-            nn.ReLU(),
-            nn.Flatten(),
-            nn.Linear(32 * num_samples, num_classes),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.net(x)
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
 
 
 def parse_args() -> argparse.Namespace:
@@ -70,7 +54,7 @@ def main() -> None:
     loader = DataLoader(ds, batch_size=args.batch_size)
 
     model = AMRClassifier(
-        SimpleCNN(args.num_samples, len(ds.classes)), num_classes=len(ds.classes)
+        ConfigurableCNN(args.num_samples, len(ds.classes)), num_classes=len(ds.classes)
     )
     if args.checkpoint:
         ckpt = torch.load(args.checkpoint, map_location="cpu")

--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -2,21 +2,7 @@ import argparse
 
 import torch
 
-from dieselwolf.models import AMRClassifier
-
-
-class SimpleCNN(torch.nn.Module):
-    def __init__(self, num_samples: int, num_classes: int) -> None:
-        super().__init__()
-        self.net = torch.nn.Sequential(
-            torch.nn.Conv1d(2, 32, kernel_size=3, padding=1),
-            torch.nn.ReLU(),
-            torch.nn.Flatten(),
-            torch.nn.Linear(32 * num_samples, num_classes),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.net(x)
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
 
 
 def parse_args() -> argparse.Namespace:
@@ -31,7 +17,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     model = AMRClassifier(
-        SimpleCNN(args.num_samples, args.num_classes), args.num_classes
+        ConfigurableCNN(args.num_samples, args.num_classes), args.num_classes
     )
     ckpt = torch.load(args.checkpoint, map_location="cpu")
     state = ckpt.get("state_dict", ckpt)

--- a/scripts/finetune_pruned.py
+++ b/scripts/finetune_pruned.py
@@ -2,25 +2,10 @@ import argparse
 
 import pytorch_lightning as pl
 import torch
-from torch import nn
 from torch.utils.data import DataLoader
 
 from dieselwolf.data import DigitalModulationDataset
-from dieselwolf.models import AMRClassifier
-
-
-class SimpleCNN(nn.Module):
-    def __init__(self, num_samples: int, num_classes: int) -> None:
-        super().__init__()
-        self.net = nn.Sequential(
-            nn.Conv1d(2, 32, kernel_size=3, padding=1),
-            nn.ReLU(),
-            nn.Flatten(),
-            nn.Linear(32 * num_samples, num_classes),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.net(x)
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
 
 
 def parse_args() -> argparse.Namespace:
@@ -31,14 +16,32 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--batch-size", type=int, default=32)
     p.add_argument("--num-examples", type=int, default=16)
     p.add_argument("--num-samples", type=int, default=512)
+    p.add_argument("--num-classes", type=int, default=None)
     return p.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    all_classes = [
+        "OOK",
+        "4ASK",
+        "8ASK",
+        "BPSK",
+        "QPSK",
+        "Pi4QPSK",
+        "8PSK",
+        "16PSK",
+        "16QAM",
+        "32QAM",
+        "64QAM",
+        "16APSK",
+        "32APSK",
+    ]
+    class_names = all_classes[: args.num_classes] if args.num_classes else "all"
     train_ds = DigitalModulationDataset(
         num_examples=args.num_examples,
         num_samples=args.num_samples,
+        classes=class_names,
         return_message=False,
         transform=None,
     )
@@ -47,14 +50,16 @@ def main() -> None:
     val_ds = DigitalModulationDataset(
         num_examples=max(1, args.num_examples // 4),
         num_samples=args.num_samples,
+        classes=class_names,
         return_message=False,
         transform=None,
     )
     val_loader = DataLoader(val_ds, batch_size=args.batch_size)
 
+    num_classes = args.num_classes or len(train_ds.classes)
     model = AMRClassifier(
-        SimpleCNN(args.num_samples, len(train_ds.classes)),
-        num_classes=len(train_ds.classes),
+        ConfigurableCNN(args.num_samples, num_classes),
+        num_classes=num_classes,
     )
     ckpt = torch.load(args.checkpoint, map_location="cpu")
     state = ckpt.get("state_dict", ckpt)

--- a/scripts/prune.py
+++ b/scripts/prune.py
@@ -4,21 +4,7 @@ from typing import List, Tuple
 import torch
 from torch.nn.utils import prune
 
-from dieselwolf.models import AMRClassifier
-
-
-class SimpleCNN(torch.nn.Module):
-    def __init__(self, num_samples: int, num_classes: int) -> None:
-        super().__init__()
-        self.net = torch.nn.Sequential(
-            torch.nn.Conv1d(2, 32, kernel_size=3, padding=1),
-            torch.nn.ReLU(),
-            torch.nn.Flatten(),
-            torch.nn.Linear(32 * num_samples, num_classes),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.net(x)
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
 
 
 def collect_prunable_layers(
@@ -51,7 +37,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     model = AMRClassifier(
-        SimpleCNN(args.num_samples, args.num_classes), args.num_classes
+        ConfigurableCNN(args.num_samples, args.num_classes), args.num_classes
     )
     ckpt = torch.load(args.checkpoint, map_location="cpu")
     state = ckpt.get("state_dict", ckpt)

--- a/tests/test_benchmark_onnx.py
+++ b/tests/test_benchmark_onnx.py
@@ -1,27 +1,14 @@
 import pytest
 import subprocess
 import torch
-from dieselwolf.models import AMRClassifier
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
 
 pytest.importorskip("onnx")
 
 
-class SimpleCNN(torch.nn.Module):
-    def __init__(self, num_samples: int, num_classes: int) -> None:
-        super().__init__()
-        self.net = torch.nn.Sequential(
-            torch.nn.Conv1d(2, 32, kernel_size=3, padding=1),
-            torch.nn.Flatten(),
-            torch.nn.Linear(32 * num_samples, num_classes),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.net(x)
-
-
 def test_benchmark_onnx(tmp_path):
     ckpt = tmp_path / "model.ckpt"
-    model = AMRClassifier(SimpleCNN(16, 4), num_classes=4)
+    model = AMRClassifier(ConfigurableCNN(16, 4), num_classes=4)
     torch.save({"state_dict": model.state_dict()}, ckpt)
     onnx_path = tmp_path / "model.onnx"
     quant_path = tmp_path / "model_int8.onnx"

--- a/tests/test_finetune_pruned.py
+++ b/tests/test_finetune_pruned.py
@@ -1,24 +1,11 @@
 import subprocess
 import torch
-from dieselwolf.models import AMRClassifier
-
-
-class SimpleCNN(torch.nn.Module):
-    def __init__(self, num_samples: int, num_classes: int) -> None:
-        super().__init__()
-        self.net = torch.nn.Sequential(
-            torch.nn.Conv1d(2, 32, kernel_size=3, padding=1),
-            torch.nn.Flatten(),
-            torch.nn.Linear(32 * num_samples, num_classes),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.net(x)
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
 
 
 def test_finetune_script(tmp_path):
     ckpt = tmp_path / "pruned.ckpt"
-    model = AMRClassifier(SimpleCNN(16, 4), num_classes=4)
+    model = AMRClassifier(ConfigurableCNN(16, 4), num_classes=4)
     torch.save({"state_dict": model.state_dict()}, ckpt)
     out_ckpt = tmp_path / "finetuned.ckpt"
     subprocess.check_call(
@@ -37,6 +24,8 @@ def test_finetune_script(tmp_path):
             "16",
             "--batch-size",
             "2",
+            "--num-classes",
+            "4",
         ]
     )
     assert out_ckpt.exists()

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,11 +1,11 @@
 import torch
 
-from dieselwolf.models import AMRClassifier
-from scripts.prune import apply_global_pruning, SimpleCNN
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
+from scripts.prune import apply_global_pruning
 
 
 def test_global_pruning_reduces_params():
-    model = AMRClassifier(SimpleCNN(16, 4), num_classes=4)
+    model = AMRClassifier(ConfigurableCNN(16, 4), num_classes=4)
     total = 0
     for p in model.parameters():
         total += p.numel()


### PR DESCRIPTION
## Summary
- introduce `ConfigurableCNN` with tunable conv layers
- update training and utility scripts to use the new configurable backbone
- allow finetune script to specify number of classes
- adjust tests to work with configurable models

## Related Issues
- roadmap task 3

------
https://chatgpt.com/codex/tasks/task_e_6866aa4a5c94832ab43f1ac681afb924