### PR TITLE
Add ray tune script for ConfigurableCNN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "pytorch-lightning==2.2.1",
     "torchmetrics==0.11.4",
     "onnxruntime==1.22.0",
+    "ray[tune]==2.47.1",
+    "tensorboard==2.19.0",
 ]
 
 [tool.black]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,5 @@ black==25.1.0
 ruff==0.4.3
 pytest
 onnxruntime==1.22.0
+ray[tune]
+tensorboard

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ transformers
 pytorch-lightning
 torchmetrics
 onnxruntime==1.22.0
+ray[tune]
+tensorboard

--- a/scripts/tune_cnn.py
+++ b/scripts/tune_cnn.py
@@ -1,0 +1,92 @@
+import argparse
+
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import TensorBoardLogger
+from ray import tune
+from ray.tune.integration.pytorch_lightning import TuneReportCallback
+from torch.utils.data import DataLoader
+
+from dieselwolf.data import DigitalModulationDataset
+from dieselwolf.data.TransformsRF import AWGN
+from dieselwolf.models import AMRClassifier, ConfigurableCNN
+
+
+def train_cnn(config: dict) -> None:
+    train_ds = DigitalModulationDataset(
+        num_examples=config["num_examples"],
+        num_samples=config["num_samples"],
+        return_message=False,
+        transform=AWGN(20),
+    )
+    val_ds = DigitalModulationDataset(
+        num_examples=max(1, config["num_examples"] // 4),
+        num_samples=config["num_samples"],
+        return_message=False,
+        transform=AWGN(20),
+    )
+    train_loader = DataLoader(train_ds, batch_size=config["batch_size"], shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=config["batch_size"])
+
+    backbone = ConfigurableCNN(
+        seq_len=config["num_samples"],
+        num_classes=len(train_ds.classes),
+        conv_channels=[config["channels1"], config["channels2"]],
+        kernel_sizes=[config["kernel1"], config["kernel2"]],
+        dropout=config["dropout"],
+    )
+    model = AMRClassifier(backbone, num_classes=len(train_ds.classes), lr=config["lr"])
+
+    logger = TensorBoardLogger(save_dir=config["log_dir"], name="")
+    trainer = pl.Trainer(
+        max_epochs=config["epochs"],
+        logger=logger,
+        enable_progress_bar=False,
+        callbacks=[
+            TuneReportCallback(
+                {"val_loss": "val_loss", "val_acc": "val_acc"}, on="validation_end"
+            )
+        ],
+        accelerator="auto",
+        devices=1,
+    )
+    trainer.fit(model, train_loader, val_loader)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Tune ConfigurableCNN with Ray Tune")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--num-examples", type=int, default=16)
+    p.add_argument("--num-samples", type=int, default=512)
+    p.add_argument("--max-trials", type=int, default=1)
+    p.add_argument("--log-dir", type=str, default="ray_results")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = {
+        "epochs": args.epochs,
+        "num_examples": args.num_examples,
+        "num_samples": args.num_samples,
+        "batch_size": tune.choice([16, 32]),
+        "lr": tune.loguniform(1e-4, 1e-2),
+        "channels1": tune.choice([16, 32, 64]),
+        "channels2": tune.choice([32, 64, 128]),
+        "kernel1": tune.choice([3, 5]),
+        "kernel2": tune.choice([3, 5]),
+        "dropout": tune.uniform(0.0, 0.5),
+        "log_dir": args.log_dir,
+    }
+
+    tune.run(
+        train_cnn,
+        resources_per_trial={"cpu": 1, "gpu": 0},
+        config=config,
+        num_samples=args.max_trials,
+        storage_path=args.log_dir,
+        name="cnn_tuning",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tune_cnn.py
+++ b/tests/test_tune_cnn.py
@@ -1,0 +1,21 @@
+import subprocess
+
+
+def test_tune_cnn_script(tmp_path):
+    subprocess.check_call(
+        [
+            "python",
+            "scripts/tune_cnn.py",
+            "--epochs",
+            "1",
+            "--num-examples",
+            "4",
+            "--num-samples",
+            "16",
+            "--max-trials",
+            "1",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- add `tune_cnn.py` to perform Ray Tune hyperparameter search on `ConfigurableCNN`
- log trial data to TensorBoard
- test the tuning CLI
- add `ray[tune]` and `tensorboard` dependencies

## Testing
- `pre-commit run --files scripts/tune_cnn.py tests/test_tune_cnn.py pyproject.toml requirements.txt requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e512b230832aa35e0005d3c2a0c0