### PR TITLE
Add fast gradient adversarial training

### DIFF
--- a/tests/test_amrclassifier.py
+++ b/tests/test_amrclassifier.py
@@ -52,3 +52,13 @@ def test_amrclassifier_training_step_channel():
     }
     loss = model.training_step(batch, 0)
     assert loss.item() > 0
+
+
+def test_amrclassifier_training_step_adversarial():
+    model = AMRClassifier(DummyNet(num_classes=3), num_classes=3, adv_eps=0.1)
+    batch = {
+        "data": torch.randn(2, 2, 2),
+        "label": torch.tensor([0, 1]),
+    }
+    loss = model.training_step(batch, 0)
+    assert loss.item() > 0

--- a/tests/test_tune_cnn.py
+++ b/tests/test_tune_cnn.py
@@ -14,6 +14,12 @@ def test_tune_cnn_script(tmp_path):
             "16",
             "--max-trials",
             "1",
+            "--adv-eps",
+            "0.0",
+            "--adv-weight",
+            "0.5",
+            "--adv-norm",
+            "inf",
             "--log-dir",
             str(tmp_path),
         ]


### PR DESCRIPTION
## Summary
- add adversarial perturbation support to `AMRClassifier`
- tune adversarial parameters in `tune_cnn.py`
- extend tests for adversarial training and tuning

## Testing
- `pre-commit run --files dieselwolf/models/lightning_module.py scripts/tune_cnn.py tests/test_amrclassifier.py tests/test_tune_cnn.py`
- `pytest tests/test_amrclassifier.py::test_amrclassifier_training_step_adversarial -q`
- ❌ `pytest tests/test_tune_cnn.py::test_tune_cnn_script -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686be3299b44832a964f59cd357f0093