### PR TITLE
Enable adversarial hyperparameter tuning

### DIFF
--- a/tests/test_tune_cnn.py
+++ b/tests/test_tune_cnn.py
@@ -16,10 +16,13 @@ def test_tune_cnn_script(tmp_path):
             "1",
             "--adv-eps",
             "0.0",
+            "0.1",
             "--adv-weight",
             "0.5",
+            "0.8",
             "--adv-norm",
             "inf",
+            "2",
             "--log-dir",
             str(tmp_path),
         ]


### PR DESCRIPTION
## Summary
- allow multiple `--adv-eps`, `--adv-weight` and `--adv-norm` values
- choose among adversarial parameters with Ray Tune
- skip GPU use when unavailable
- update test to exercise new CLI

## Testing
- `pre-commit run --files scripts/tune_cnn.py tests/test_tune_cnn.py`
- `pytest -q tests/test_tune_cnn.py`

------
https://chatgpt.com/codex/tasks/task_e_686beac5dae8832a80df8a53b5aecb5c