### PR TITLE
Fix transformer normalization

### DIFF
--- a/dieselwolf/complex_layers.py
+++ b/dieselwolf/complex_layers.py
@@ -60,3 +60,18 @@ class ComplexLinear(nn.Module):
     def reset_parameters(self) -> None:
         self.real.reset_parameters()
         self.imag.reset_parameters()
+
+
+class ComplexLayerNorm(nn.Module):
+    """LayerNorm for complex inputs applied separately to real and imaginary parts."""
+
+    def __init__(self, normalized_shape: int) -> None:
+        super().__init__()
+        self.real = nn.LayerNorm(normalized_shape)
+        self.imag = nn.LayerNorm(normalized_shape)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_r, x_i = x.chunk(2, dim=1)
+        real = self.real(x_r.permute(0, 2, 1)).permute(0, 2, 1)
+        imag = self.imag(x_i.permute(0, 2, 1)).permute(0, 2, 1)
+        return torch.cat([real, imag], dim=1)

--- a/dieselwolf/models/complex_transformer.py
+++ b/dieselwolf/models/complex_transformer.py
@@ -2,7 +2,7 @@ import math
 import torch
 from torch import nn
 
-from ..complex_layers import ComplexLinear, ComplexBatchNorm1d
+from ..complex_layers import ComplexLinear, ComplexLayerNorm
 
 
 class SinusoidalPositionalEncoding(nn.Module):
@@ -39,8 +39,8 @@ class ComplexTransformerEncoderLayer(nn.Module):
         self.dropout = nn.Dropout(dropout)
         self.linear2 = ComplexLinear(dim_feedforward, d_model)
 
-        self.norm1 = ComplexBatchNorm1d(d_model)
-        self.norm2 = ComplexBatchNorm1d(d_model)
+        self.norm1 = ComplexLayerNorm(d_model)
+        self.norm2 = ComplexLayerNorm(d_model)
         self.dropout1 = nn.Dropout(dropout)
         self.dropout2 = nn.Dropout(dropout)
         self.activation = nn.ReLU()

--- a/tests/test_complex_layers.py
+++ b/tests/test_complex_layers.py
@@ -1,5 +1,10 @@
 import torch
-from dieselwolf.complex_layers import ComplexConv1d, ComplexBatchNorm1d, ComplexLinear
+from dieselwolf.complex_layers import (
+    ComplexConv1d,
+    ComplexBatchNorm1d,
+    ComplexLinear,
+    ComplexLayerNorm,
+)
 
 
 class DummyModel(torch.nn.Module):
@@ -35,3 +40,10 @@ def test_weight_initialisation():
     layer = ComplexLinear(8, 4)
     for param in layer.parameters():
         assert param.abs().sum() > 0
+
+
+def test_layernorm_shape():
+    norm = ComplexLayerNorm(4)
+    x = torch.randn(2, 8, 16)
+    out = norm(x)
+    assert out.shape == x.shape


### PR DESCRIPTION
## Summary
- add ComplexLayerNorm to handle per-token normalization for complex tensors
- switch ComplexTransformer to use layer norm
- test ComplexLayerNorm with shape check

## Testing
- `pre-commit run --files dieselwolf/complex_layers.py dieselwolf/models/complex_transformer.py tests/test_complex_layers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bff773d2c832a8ae3c159e275f04e