### PR TITLE
Add MobileRaT tuning script and adversarial options

### DIFF
--- a/dieselwolf/models/__init__.py
+++ b/dieselwolf/models/__init__.py
@@ -4,6 +4,8 @@ from .lightning_module import AMRClassifier
 from .complex_transformer import ComplexTransformerEncoder
 from .configurable_cnn import ConfigurableCNN
 from .configurable_mobile_rat import ConfigurableMobileRaT
+from .mobile_rat import MobileRaT
+from .nmformer import NMformer
 from .moco_v3 import MoCoV3
 from .factory import build_backbone
 
@@ -11,6 +13,8 @@ __all__ = [
     "AMRClassifier",
     "ComplexTransformerEncoder",
     "ConfigurableMobileRaT",
+    "MobileRaT",
+    "NMformer",
     "ConfigurableCNN",
     "MoCoV3",
     "build_backbone",

--- a/dieselwolf/models/factory.py
+++ b/dieselwolf/models/factory.py
@@ -8,11 +8,15 @@ from torch import nn
 
 from .configurable_cnn import ConfigurableCNN
 from .configurable_mobile_rat import ConfigurableMobileRaT
+from .mobile_rat import MobileRaT
+from .nmformer import NMformer
 
 
 _BACKBONES = {
     "ConfigurableMobileRaT": ConfigurableMobileRaT,
     "ConfigurableCNN": ConfigurableCNN,
+    "MobileRaT": MobileRaT,
+    "NMformer": NMformer,
 }
 
 

--- a/dieselwolf/models/mobile_rat.py
+++ b/dieselwolf/models/mobile_rat.py
@@ -1,0 +1,38 @@
+import torch
+from torch import nn
+
+from ..complex_layers import ComplexBatchNorm1d, ComplexConv1d
+from .complex_transformer import ComplexTransformerEncoder
+
+
+class MobileRaT(nn.Module):
+    """Lightweight complex-valued Radio Transformer backbone."""
+
+    def __init__(
+        self,
+        seq_len: int,
+        num_classes: int,
+        d_model: int = 32,
+        nhead: int = 4,
+        num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+        self.seq_len = seq_len
+        self.frontend = nn.Sequential(
+            ComplexConv1d(1, d_model, kernel_size=3, padding=1),
+            ComplexBatchNorm1d(d_model),
+            nn.ReLU(),
+        )
+        self.transformer = ComplexTransformerEncoder(
+            d_model=d_model,
+            nhead=nhead,
+            num_layers=num_layers,
+            seq_len=seq_len,
+        )
+        self.classifier = nn.Linear(2 * d_model * seq_len, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.frontend(x)
+        x = self.transformer(x)
+        x = x.flatten(1)
+        return self.classifier(x)

--- a/dieselwolf/models/nmformer.py
+++ b/dieselwolf/models/nmformer.py
@@ -1,0 +1,45 @@
+import torch
+from torch import nn
+
+from ..complex_layers import ComplexBatchNorm1d, ComplexConv1d
+from .complex_transformer import ComplexTransformerEncoder
+
+
+class NMformer(nn.Module):
+    """Transformer backbone with noise token augmentation."""
+
+    def __init__(
+        self,
+        seq_len: int,
+        num_classes: int,
+        d_model: int = 32,
+        nhead: int = 4,
+        num_layers: int = 2,
+        num_noise_tokens: int = 2,
+    ) -> None:
+        super().__init__()
+        self.seq_len = seq_len
+        self.num_noise_tokens = num_noise_tokens
+        self.frontend = nn.Sequential(
+            ComplexConv1d(1, d_model, kernel_size=3, padding=1),
+            ComplexBatchNorm1d(d_model),
+            nn.ReLU(),
+        )
+        total_len = seq_len + num_noise_tokens
+        self.transformer = ComplexTransformerEncoder(
+            d_model=d_model,
+            nhead=nhead,
+            num_layers=num_layers,
+            seq_len=total_len,
+        )
+        self.classifier = nn.Linear(2 * d_model * total_len, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.frontend(x)
+        noise = torch.randn(
+            x.size(0), x.size(1), self.num_noise_tokens, device=x.device
+        )
+        x = torch.cat([x, noise], dim=2)
+        x = self.transformer(x)
+        x = x.flatten(1)
+        return self.classifier(x)

--- a/scripts/tune_mobilerat.py
+++ b/scripts/tune_mobilerat.py
@@ -1,0 +1,135 @@
+import argparse
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import TensorBoardLogger
+from ray import tune
+from ray.tune.integration.pytorch_lightning import TuneReportCallback
+from torch.utils.data import DataLoader
+import torch
+
+from dieselwolf.data import DigitalModulationDataset
+from dieselwolf.data.TransformsRF import AWGN
+from dieselwolf.models import AMRClassifier, ConfigurableMobileRaT
+
+
+def train_mobile_rat(config: dict) -> None:
+    train_ds = DigitalModulationDataset(
+        num_examples=config["num_examples"],
+        num_samples=config["num_samples"],
+        return_message=False,
+        transform=AWGN(20),
+    )
+    val_ds = DigitalModulationDataset(
+        num_examples=max(1, config["num_examples"] // 4),
+        num_samples=config["num_samples"],
+        return_message=False,
+        transform=AWGN(20),
+    )
+    train_loader = DataLoader(train_ds, batch_size=config["batch_size"], shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=config["batch_size"])
+
+    backbone = ConfigurableMobileRaT(
+        seq_len=config["num_samples"],
+        num_classes=len(train_ds.classes),
+        conv_channels=[config["channels1"], config["channels2"]],
+        kernel_sizes=[config["kernel1"], config["kernel2"]],
+        dropout=config["dropout"],
+        nhead=config["nhead"],
+        num_layers=config["num_layers"],
+    )
+    model = AMRClassifier(
+        backbone,
+        num_classes=len(train_ds.classes),
+        lr=config["lr"],
+        adv_eps=config["adv_eps"],
+        adv_weight=config["adv_weight"],
+        adv_norm=config["adv_norm"],
+    )
+
+    logger = TensorBoardLogger(save_dir=config["log_dir"], name="")
+    trainer = pl.Trainer(
+        max_epochs=config["epochs"],
+        logger=logger,
+        enable_progress_bar=False,
+        callbacks=[
+            TuneReportCallback(
+                {"val_loss": "val_loss", "val_acc": "val_acc"}, on="validation_end"
+            )
+        ],
+        accelerator="auto",
+        devices=1,
+    )
+    trainer.fit(model, train_loader, val_loader)
+
+
+def _float_or_inf(value: str) -> float:
+    """Parse a float value that may be 'inf'."""
+
+    if value == "inf":
+        return float("inf")
+    return float(value)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Tune ConfigurableMobileRaT with Ray Tune")
+    p.add_argument("--epochs", type=int, default=20)
+    p.add_argument("--num-examples", type=int, default=2**12)
+    p.add_argument("--num-samples", type=int, default=512)
+    p.add_argument("--max-trials", type=int, default=20)
+    p.add_argument(
+        "--adv-eps",
+        type=float,
+        nargs="+",
+        default=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+        help="Adversarial eps values",
+    )
+    p.add_argument(
+        "--adv-weight",
+        type=float,
+        nargs="+",
+        default=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+        help="Adversarial loss weight values",
+    )
+    p.add_argument(
+        "--adv-norm",
+        type=_float_or_inf,
+        nargs="+",
+        default=[float("inf"), float(1), float(2)],
+        help="Gradient norm types to try",
+    )
+    p.add_argument("--log-dir", type=str, default="/app/ray_results")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = {
+        "epochs": args.epochs,
+        "num_examples": args.num_examples,
+        "num_samples": args.num_samples,
+        "batch_size": tune.choice([16, 32]),
+        "lr": tune.loguniform(1e-4, 1e-2),
+        "channels1": tune.choice([16, 32, 64]),
+        "channels2": tune.choice([32, 64, 128]),
+        "kernel1": tune.choice([3, 5]),
+        "kernel2": tune.choice([3, 5]),
+        "dropout": tune.uniform(0.0, 0.5),
+        "nhead": tune.choice([2, 4, 8]),
+        "num_layers": tune.choice([1, 2, 3]),
+        "adv_eps": tune.choice(args.adv_eps),
+        "adv_weight": tune.choice(args.adv_weight),
+        "adv_norm": tune.choice(args.adv_norm),
+        "log_dir": args.log_dir,
+    }
+
+    tune.run(
+        train_mobile_rat,
+        resources_per_trial={"cpu": 1, "gpu": 1 if torch.cuda.is_available() else 0},
+        config=config,
+        num_samples=args.max_trials,
+        storage_path=args.log_dir,
+        name="mobilerat_tuning",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `MobileRaT` and `NMformer` backbones for tests
- expose adversarial training options in `train_amr.py`
- log training with TensorBoard
- add a Ray Tune script for `ConfigurableMobileRaT`

## Testing
- `pre-commit run --files scripts/train_amr.py scripts/tune_mobilerat.py dieselwolf/models/mobile_rat.py dieselwolf/models/nmformer.py dieselwolf/models/__init__.py dieselwolf/models/factory.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1c474798832a99e46157878bcbb8