### PR TITLE
Add confusion matrix callback

### DIFF
--- a/dieselwolf/__init__.py
+++ b/dieselwolf/__init__.py
@@ -1,4 +1,4 @@
-from .callbacks import SNRCurriculumCallback
+from .callbacks import ConfusionMatrixCallback, SNRCurriculumCallback
 from .models import build_backbone
 
-__all__ = ["SNRCurriculumCallback", "build_backbone"]
+__all__ = ["SNRCurriculumCallback", "ConfusionMatrixCallback", "build_backbone"]

--- a/dieselwolf/callbacks.py
+++ b/dieselwolf/callbacks.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import os
+from typing import List
+
+import matplotlib.pyplot as plt
 import pytorch_lightning as pl
+import torch
+from sklearn.metrics import confusion_matrix as sk_confusion_matrix
 
 
 class SNRCurriculumCallback(pl.Callback):
@@ -57,3 +63,78 @@ class SNRCurriculumCallback(pl.Callback):
                 self.current_snr -= self.step
                 self._set_snr()
                 self.wait = 0
+
+
+class ConfusionMatrixCallback(pl.Callback):
+    """Generate a confusion matrix on a separate dataloader after each epoch."""
+
+    def __init__(
+        self,
+        dataloader,
+        output_dir: str | None = None,
+        log_tag: str = "confusion_matrix",
+    ) -> None:
+        self.dataloader = dataloader
+        self.output_dir = output_dir
+        self.log_tag = log_tag
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+
+    def _evaluate(self, pl_module: pl.LightningModule) -> torch.Tensor:
+        pl_module.eval()
+        preds: List[int] = []
+        targets: List[int] = []
+        device = pl_module.device
+        with torch.no_grad():
+            for batch in self.dataloader:
+                x = batch["data"].to(device)
+                y = batch["label"].to(device)
+                logits = pl_module(x)
+                preds.extend(logits.argmax(dim=1).cpu().tolist())
+                targets.extend(y.cpu().tolist())
+        return torch.tensor(
+            sk_confusion_matrix(
+                targets, preds, labels=list(range(len(self.dataloader.dataset.classes)))
+            )
+        )
+
+    def _plot(self, cm: torch.Tensor) -> plt.Figure:
+        fig, ax = plt.subplots(figsize=(6, 5))
+        im = ax.imshow(cm, cmap="Blues")
+        classes = self.dataloader.dataset.classes
+        for i in range(len(classes)):
+            for j in range(len(classes)):
+                val = cm[i, j] / max(1, cm[i].sum())
+                color = "white" if val > 0.7 else "black"
+                ax.text(
+                    j,
+                    i,
+                    f"{val*100:2.1f}%",
+                    ha="center",
+                    va="center",
+                    color=color,
+                    fontsize=8,
+                )
+        ax.set_xticks(range(len(classes)))
+        ax.set_xticklabels(classes, rotation=90, fontsize=8)
+        ax.set_yticks(range(len(classes)))
+        ax.set_yticklabels(classes, fontsize=8)
+        ax.set_xlabel("Predicted")
+        ax.set_ylabel("True")
+        fig.colorbar(im, ax=ax)
+        fig.tight_layout()
+        return fig
+
+    def on_validation_epoch_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        cm = self._evaluate(pl_module)
+        fig = self._plot(cm)
+        if self.output_dir:
+            path = os.path.join(self.output_dir, f"epoch_{trainer.current_epoch}.png")
+            fig.savefig(path)
+        if trainer.logger and hasattr(trainer.logger, "experiment"):
+            trainer.logger.experiment.add_figure(
+                self.log_tag, fig, global_step=trainer.current_epoch
+            )
+        plt.close(fig)

--- a/notebooks/Training_Tutorial.ipynb
+++ b/notebooks/Training_Tutorial.ipynb
@@ -20,7 +20,7 @@
     "from dieselwolf.data import DigitalModulationDataset\n",
     "from dieselwolf.data.TransformsRF import AWGN\n",
     "from dieselwolf.models import AMRClassifier, ConfigurableMobileRaT\n",
-    "from dieselwolf.callbacks import SNRCurriculumCallback\n",
+  "from dieselwolf.callbacks import SNRCurriculumCallback, ConfusionMatrixCallback\n",
     "import pytorch_lightning as pl\n",
     "from pytorch_lightning.callbacks import LearningRateMonitor\n",
     "from torch.utils.data import DataLoader"
@@ -40,9 +40,20 @@
     "train_ds = DigitalModulationDataset(num_examples=50, num_samples=128, transform=AWGN(20))\n",
     "val_ds = DigitalModulationDataset(num_examples=50, num_samples=128, transform=AWGN(20))\n",
     "train_loader = DataLoader(train_ds, batch_size=2, shuffle=True)\n",
-    "val_loader = DataLoader(val_ds, batch_size=2)"
-   ]
-  },
+  "val_loader = DataLoader(val_ds, batch_size=2)"
+  ]
+ },
+ {
+  "cell_type": "code",
+  "execution_count": null,
+  "id": "c518fefc",
+  "metadata": {},
+  "outputs": [],
+  "source": [
+   "test_ds = DigitalModulationDataset(num_examples=20, num_samples=128, transform=AWGN(20))\n",
+   "test_loader = DataLoader(test_ds, batch_size=2)"
+  ]
+ },
   {
    "cell_type": "code",
    "execution_count": null,
@@ -65,9 +76,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "callbacks=[LearningRateMonitor(), SNRCurriculumCallback(train_ds, start_snr=20, patience=1)]\n",
-    "trainer = pl.Trainer(max_epochs=1, enable_progress_bar=False)\n",
-    "trainer.fit(model, train_loader, val_loader)"
+  "callbacks = [\n",
+  "    LearningRateMonitor(),\n",
+  "    SNRCurriculumCallback(train_ds, start_snr=20, patience=1),\n",
+  "    ConfusionMatrixCallback(test_loader, output_dir=\"confusion_images\"),\n",
+  "]\n",
+  "trainer = pl.Trainer(max_epochs=1, enable_progress_bar=False, callbacks=callbacks)\n",
+  "trainer.fit(model, train_loader, val_loader)"
    ]
   },
   {
@@ -75,9 +90,18 @@
    "id": "99326a63",
    "metadata": {},
    "source": [
-    "The model trains for a single epoch for speed. In a real experiment you would run for many more epochs."
-   ]
-  }
+  "The model trains for a single epoch for speed. In a real experiment you would run for many more epochs."
+ ],
+ "metadata": {}
+ },
+ {
+  "cell_type": "markdown",
+  "id": "b1f074b6",
+  "metadata": {},
+  "source": [
+   "The `ConfusionMatrixCallback` saves images under `confusion_images/` each epoch."
+  ]
+ }
  ],
  "metadata": {
   "kernelspec": {

--- a/scripts/quantize_onnx.py
+++ b/scripts/quantize_onnx.py
@@ -7,12 +7,24 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Quantize ONNX model to INT8")
     p.add_argument("--input", type=str, required=True)
     p.add_argument("--output", type=str, required=True)
+    p.add_argument(
+        "--op-types",
+        type=str,
+        default="MatMul,Gemm",
+        help="Comma-separated operator types to quantize",
+    )
     return p.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    quantize_dynamic(args.input, args.output, weight_type=QuantType.QInt8)
+    op_types = [op.strip() for op in args.op_types.split(",") if op.strip()]
+    quantize_dynamic(
+        args.input,
+        args.output,
+        weight_type=QuantType.QInt8,
+        op_types_to_quantize=op_types,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support confusion matrix visualisation during training
- exclude conv ops during ONNX quantisation
- export new callback via `dieselwolf.__init__`
- update training tutorial to demonstrate all callbacks

## Testing
- `pre-commit run --files dieselwolf/callbacks.py dieselwolf/__init__.py scripts/quantize_onnx.py notebooks/Training_Tutorial.ipynb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d252b81c4832a9ad5570cb21367c1