### PR TITLE
Fix Lookahead defaults for LR monitor

### DIFF
--- a/dieselwolf/optim.py
+++ b/dieselwolf/optim.py
@@ -66,3 +66,8 @@ class Lookahead(Optimizer):
     @property
     def state(self) -> Dict:
         return self.optimizer.state
+
+    @property
+    def defaults(self) -> Dict:
+        """Return defaults of the wrapped optimizer."""
+        return getattr(self.optimizer, "defaults", {})


### PR DESCRIPTION
## Summary
- expose `defaults` on `Lookahead` to make PyTorch Lightning's `LearningRateMonitor` happy

References AGENTS checklist bullet:
- **Switch default to Lookahead(AdamW)** (`00a5384`)

## Testing
- `pre-commit run --files dieselwolf/optim.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d29d9d1f8832aa7ae1cab42beaef3