### PR TITLE
Improve callback metrics and curriculum

### DIFF
--- a/notebooks/Training_Tutorial.ipynb
+++ b/notebooks/Training_Tutorial.ipynb
@@ -18,7 +18,7 @@
    "source": [
     "import make_paths_absolute\n",
     "from dieselwolf.data import DigitalModulationDataset\n",
-    "from dieselwolf.data.TransformsRF import AWGN\n",
+    "from dieselwolf.data.TransformsRF import AWGN, RandomAWGN\n",
     "from dieselwolf.models import AMRClassifier, ConfigurableMobileRaT, ConfigurableCNN\n",
     "from dieselwolf.callbacks import SNRCurriculumCallback, ConfusionMatrixCallback\n",
     "import pytorch_lightning as pl\n",
@@ -37,7 +37,7 @@
    },
    "outputs": [],
    "source": [
-    "train_ds = DigitalModulationDataset(num_examples=50, num_samples=128, transform=AWGN(20))\n",
+    "train_ds = DigitalModulationDataset(num_examples=50, num_samples=128, transform=RandomAWGN(20, 20))\n",
     "val_ds = DigitalModulationDataset(num_examples=50, num_samples=128, transform=AWGN(0))\n",
     "train_loader = DataLoader(train_ds, batch_size=2, shuffle=True)\n",
     "val_loader = DataLoader(val_ds, batch_size=2)"


### PR DESCRIPTION
## Summary
- show SNR adjustments when the curriculum changes
- compute average SNR, loss and accuracy in the confusion matrix plot
- tweak RandomAWGN curriculum to only lower the `low` bound
- demonstrate the new features in `Training_Tutorial.ipynb`

## Testing
- `pre-commit run --files dieselwolf/callbacks.py notebooks/Training_Tutorial.ipynb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d33e1fd60832a9f83b0205bbb69fc