### PR TITLE
Add confusion matrix callback to tuning scripts

### DIFF
--- a/tests/test_tune_mobilerat.py
+++ b/tests/test_tune_mobilerat.py
@@ -1,0 +1,30 @@
+import subprocess
+
+
+def test_tune_mobilerat_script(tmp_path):
+    subprocess.check_call(
+        [
+            "python",
+            "scripts/tune_mobilerat.py",
+            "--epochs",
+            "1",
+            "--num-examples",
+            "4",
+            "--num-samples",
+            "16",
+            "--max-trials",
+            "1",
+            "--adv-eps",
+            "0.0",
+            "0.1",
+            "--adv-weight",
+            "0.5",
+            "0.8",
+            "--adv-norm",
+            "inf",
+            "2",
+            "--log-dir",
+            str(tmp_path),
+        ]
+    )
+    assert any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- integrate `ConfusionMatrixCallback` into CNN and MobileRaT tuning scripts
- exercise MobileRaT tuner in unit tests

## Testing
- `pre-commit run --files scripts/tune_cnn.py scripts/tune_mobilerat.py tests/test_tune_mobilerat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4eb285f0832aaf8dde35ad82ff97