### PR TITLE
Add latent space projection callback

### DIFF
--- a/dieselwolf/__init__.py
+++ b/dieselwolf/__init__.py
@@ -1,4 +1,13 @@
-from .callbacks import ConfusionMatrixCallback, SNRCurriculumCallback
+from .callbacks import (
+    ConfusionMatrixCallback,
+    LatentSpaceCallback,
+    SNRCurriculumCallback,
+)
 from .models import build_backbone
 
-__all__ = ["SNRCurriculumCallback", "ConfusionMatrixCallback", "build_backbone"]
+__all__ = [
+    "SNRCurriculumCallback",
+    "ConfusionMatrixCallback",
+    "LatentSpaceCallback",
+    "build_backbone",
+]

--- a/scripts/tune_cnn.py
+++ b/scripts/tune_cnn.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import time
 import pytorch_lightning as pl
 from pytorch_lightning.loggers import TensorBoardLogger
@@ -6,7 +7,7 @@ from pytorch_lightning.callbacks import EarlyStopping
 from ray import tune
 from ray.tune.integration.pytorch_lightning import TuneReportCallback
 from ray.tune.search.bayesopt import BayesOptSearch
-from dieselwolf.callbacks import ConfusionMatrixCallback
+from dieselwolf.callbacks import ConfusionMatrixCallback, LatentSpaceCallback
 from torch.utils.data import DataLoader
 import torch
 
@@ -56,6 +57,11 @@ def train_cnn(config: dict) -> None:
     )
 
     logger = TensorBoardLogger(save_dir=config["log_dir"], name="")
+    latent_cb = LatentSpaceCallback(
+        val_loader,
+        output_dir=os.path.join(logger.log_dir, "latent_space"),
+        log_tag="val_latent",
+    )
     trainer = pl.Trainer(
         max_epochs=config["epochs"],
         logger=logger,
@@ -65,6 +71,7 @@ def train_cnn(config: dict) -> None:
                 {"val_loss": "val_loss", "val_acc": "val_acc"}, on="validation_end"
             ),
             cm_callback,
+            latent_cb,
             EarlyStopping(monitor="val_loss", mode="min", patience=5),
         ],
         accelerator="auto",


### PR DESCRIPTION
## Summary
- add LatentSpaceCallback to capture embeddings and metadata
- re-export callback in `__init__`
- log latent space on best epoch in tune scripts

## Testing
- `ruff dieselwolf/callbacks.py dieselwolf/__init__.py scripts/tune_cnn.py scripts/tune_mobilerat.py`
- `black dieselwolf/callbacks.py dieselwolf/__init__.py scripts/tune_cnn.py scripts/tune_mobilerat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8b8be23c832a8427e42b5bf3f9ba